### PR TITLE
mnemonicToSeed -> mnemonicToSeedBuffer, mnemonicToSeedHex -> mnemonicToSeed

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,11 +5,11 @@ var pbkdf2 = require('pbkdf2-compat').pbkdf2Sync
 var DEFAULT_WORDLIST = require('./wordlists/en.json')
 
 function mnemonicToSeed(mnemonic, password) {
-  return pbkdf2(mnemonic, salt(password), 2048, 64, 'sha512')
+  return mnemonicToSeedBuffer(mnemonic, password).toString('hex')
 }
 
-function mnemonicToSeedHex(mnemonic, password) {
-  return mnemonicToSeed(mnemonic, password).toString('hex')
+function mnemonicToSeedBuffer(mnemonic, password) {
+  return pbkdf2(mnemonic, salt(password), 2048, 64, 'sha512')
 }
 
 function mnemonicToEntropy(mnemonic, wordlist) {
@@ -117,7 +117,7 @@ function lpad(str, padString, length) {
 
 module.exports = {
   mnemonicToSeed: mnemonicToSeed,
-  mnemonicToSeedHex: mnemonicToSeedHex,
+  mnemonicToSeedBuffer: mnemonicToSeedBuffer,
   mnemonicToEntropy: mnemonicToEntropy,
   entropyToMnemonic: entropyToMnemonic,
   generateMnemonic: generateMnemonic,

--- a/test/index.js
+++ b/test/index.js
@@ -11,12 +11,12 @@ var wordlists = {
 var vectors = require('./vectors.json')
 
 describe('BIP39', function() {
-  describe('mnemonicToSeedHex', function() {
+  describe('mnemonicToSeed', function() {
     this.timeout(20000)
 
     vectors.english.forEach(function(v, i) {
       it('works for tests vector ' + i, function() {
-        assert.equal(BIP39.mnemonicToSeedHex(v[1], 'TREZOR'), v[2])
+        assert.equal(BIP39.mnemonicToSeed(v[1], 'TREZOR'), v[2])
       })
     })
   })


### PR DESCRIPTION
mnemonicToEntropy exports in hex format, this change makes the naming more consistent.
I would like to keep the default/shorter interface names return primitive data types,
as it is more browser friendly.