### PR TITLE
Use browserify packages directly

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,10 @@ var unorm = require('unorm')
 var DEFAULT_WORDLIST = require('./wordlists/en.json')
 
 function mnemonicToSeed(mnemonic, password) {
-  return pbkdf2(mnemonic, salt(password), 2048, 64, 'sha512')
+  var mnemonicBuffer = new Buffer(mnemonic, 'utf8')
+  var saltBuffer = new Buffer(salt(password), 'utf8')
+
+  return pbkdf2(mnemonicBuffer, saltBuffer, 2048, 64, 'sha512')
 }
 
 function mnemonicToSeedHex(mnemonic, password) {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var assert = require('assert')
 var crypto = require('crypto')
 var pbkdf2 = require('pbkdf2-compat').pbkdf2Sync
+var randomBytes = require('randombytes')
 var unorm = require('unorm')
 
 var DEFAULT_WORDLIST = require('./wordlists/en.json')
@@ -69,7 +70,7 @@ function entropyToMnemonic(entropy, wordlist) {
 
 function generateMnemonic(strength, rng, wordlist) {
   strength = strength || 128
-  rng = rng || crypto.randomBytes
+  rng = rng || randomBytes
 
   var hex = rng(strength / 8).toString('hex')
   return entropyToMnemonic(hex, wordlist)

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var assert = require('assert')
-var crypto = require('crypto')
-var pbkdf2 = require('pbkdf2-compat').pbkdf2Sync
+var createHash = require('create-hash')
+var pbkdf2 = require('pbkdf2').pbkdf2Sync
 var randomBytes = require('randombytes')
 var unorm = require('unorm')
 
@@ -87,7 +87,7 @@ function validateMnemonic(mnemonic, wordlist) {
 }
 
 function checksumBits(entropyBuffer) {
-  var hash = crypto.createHash('sha256').update(entropyBuffer).digest()
+  var hash = createHash('sha256').update(entropyBuffer).digest()
 
   // Calculated constants from BIP39
   var ENT = entropyBuffer.length * 8

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "license": "ISC",
   "dependencies": {
     "pbkdf2-compat": "^2.0.1",
+    "randombytes": "^2.0.1",
     "unorm": "^1.3.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "browserify": "^9.0.0",
-    "mocha": "^2.2.0"
+    "mocha": "^2.2.0",
+    "mock-require": "^1.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,13 +21,14 @@
   },
   "license": "ISC",
   "dependencies": {
-    "pbkdf2-compat": "^2.0.1",
+    "create-hash": "^1.1.0",
+    "pbkdf2": "^3.0.0",
     "randombytes": "^2.0.1",
     "unorm": "^1.3.3"
   },
   "devDependencies": {
-    "browserify": "^8.0.3",
-    "mocha": "^2.1.0",
+    "browserify": "^9.0.0",
+    "mocha": "^2.2.0",
     "sinon": "^1.12.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   },
   "devDependencies": {
     "browserify": "^9.0.0",
-    "mocha": "^2.2.0",
-    "sinon": "^1.12.2"
+    "mocha": "^2.2.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,5 @@
 var assert = require('assert')
-var crypto = require('crypto')
 var BIP39 = require('../index.js')
-var sinon = require('sinon')
 
 var wordlists = {
   english: require('../wordlists/en.json'),
@@ -51,13 +49,11 @@ describe('BIP39', function() {
 
   describe('generateMnemonic', function() {
     vectors.english.forEach(function(v, i) {
-      it('works for tests vector ' + i, sinon.test(function() {
-        this.mock(crypto).expects('randomBytes')
-          .exactly(1)
-          .onCall(0).returns(new Buffer(v[0], 'hex'))
+      it('works for tests vector ' + i, function() {
+        function rng() { return new Buffer(v[0], 'hex') }
 
-        assert.equal(BIP39.generateMnemonic(), v[1])
-      }))
+        assert.equal(BIP39.generateMnemonic(undefined, rng), v[1])
+      })
     })
 
     it('can vary generated entropy bit length', function() {

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,10 @@
 var assert = require('assert')
+var mock = require('mock-require')
+
+mock('randombytes', function(size) {
+  return new Buffer('qwertyuiopasdfghjklzxcvbnm[];,./'.slice(0, size))
+})
+
 var BIP39 = require('../index.js')
 
 var wordlists = {
@@ -61,6 +67,10 @@ describe('BIP39', function() {
       var words = mnemonic.split(' ')
 
       assert.equal(words.length, 9)
+    })
+
+    it('defaults to randombytes for the RNG', function() {
+      assert.equal(BIP39.generateMnemonic(32), 'imitate robot frequent')
     })
 
     it('allows a custom RNG to be used', function() {


### PR DESCRIPTION
This PR is not-dissimilar to using `inherits` over `util.inherits`.

It also exposed a [bug](https://github.com/crypto-browserify/pbkdf2/issues/11) (in Node?), and is therefore blocked by it for now.